### PR TITLE
Single char change to fix import error

### DIFF
--- a/zca/__init__.py
+++ b/zca/__init__.py
@@ -3,5 +3,5 @@
 __version__ = '0.1.0'
 __author__ = 'Maarten Versteegh <maartenversteegh@gmail.com>'
 
-from zca import ZCA
+from .zca import ZCA
 __all__ = ['ZCA']


### PR DESCRIPTION
Think this might be py3 specific behavior that causes this import to fail.  It's because of the conflict between the top level package name and zca.py file name.  Should use an explicit relative import or absolute import here.

https://www.python.org/dev/peps/pep-0008/#imports